### PR TITLE
fix: 500 on create session - missing body

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -60,9 +60,10 @@ const apiRequest = async <T>(
 }
 
 // Session Management
-export const createSession = async (): Promise<Session> => {
+export const createSession = async (options?: { parentID?: string; title?: string }): Promise<Session> => {
   return apiRequest<Session>('/session', {
-    method: 'POST'
+    method: 'POST',
+    body: options ? JSON.stringify(options) : JSON.stringify({})
   })
 }
 


### PR DESCRIPTION
There's a 500 when `POST /session` is called. The server requires a body to be included - but currently there's an empty payload.

```

POST | /session | Create session | body: { parentID?, title? }, returns Session
-- | -- | -- | --

POST	/session	Create session	body: { parentID?, title? }, returns [Session](https://github.com/sst/opencode/blob/dev/packages/sdk/js/src/gen/types.gen.ts)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced session creation with support for optional parent ID and title parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->