### PR TITLE
fix: 400 on send message - malformed message id

### DIFF
--- a/src/utils/apiHelpers.ts
+++ b/src/utils/apiHelpers.ts
@@ -54,6 +54,11 @@ const generateId = (): string => {
   return crypto.randomUUID()
 }
 
+// Message ID generation with required prefix
+const generateMessageId = (): string => {
+  return `msg_${crypto.randomUUID()}`
+}
+
 // Message creation helpers
 export const createTextMessageRequest = (
   text: string,
@@ -62,7 +67,7 @@ export const createTextMessageRequest = (
   modelID: string = DEFAULT_SETTINGS.MODEL,
   mode: string = 'build'
 ): SendMessageRequest => {
-  const messageID = generateId()
+  const messageID = generateMessageId()
   return {
     messageID,
     providerID,
@@ -86,7 +91,7 @@ export const createFileMessageRequest = (
   modelID: string = DEFAULT_SETTINGS.MODEL,
   mode: string = 'build'
 ): SendMessageRequest => {
-  const messageID = generateId()
+  const messageID = generateMessageId()
   return {
     messageID,
     providerID,
@@ -109,7 +114,7 @@ export const createMixedMessageRequest = (
   modelID: string = DEFAULT_SETTINGS.MODEL,
   mode: string = 'build'
 ): SendMessageRequest => ({
-  messageID: generateId(),
+  messageID: generateMessageId(),
   providerID,
   modelID,
   mode,


### PR DESCRIPTION
Summary

- Fix POST /session/:id/message 400 error: Updated message ID generation to use required 'msg' prefix

Changes

- Added generateMessageId() function in src/utils/apiHelpers.ts to create message IDs with 'msg_' prefix
- Updated all message creation functions to use proper message ID formatting

Impact

Resolves server-side validation errors that were preventing session creation and message sending functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Refactor
* Optimized internal message ID generation with consistent prefixing for improved system consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->